### PR TITLE
Update workflows for Node 18

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,3 @@
+paths-ignore:
+  - node_modules
+  - '**/*.test.js'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: "Code quality"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: '43 23 * * 1'
+
+jobs:
+  analyze:
+    name: JavaScript
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        config-file: ./.github/codeql/codeql-config.yml
+        languages: javascript
+
+    - name: Perform CodeQL analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Linting
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint:
+    name: JavaScript
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install peer dependencies
+        run: npx npm-install-peers
+
+      - name: Run linter
+        run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test
 
 on:
   push:
@@ -7,36 +7,15 @@ on:
     branches: [ master ]
 
 jobs:
-  lint:
-    name: Run linter
+  test-node-18:
+    name: Node.js v18
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '16'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run linter
-        run: npm run lint
-
-  test-node-16:
-    name: Test Node.js v16
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-
-      - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.3.0
-        with:
-          mongodb-version: '4.0'
+          node-version: '18'
 
       - name: Install dependencies
         run: npm ci
@@ -47,20 +26,31 @@ jobs:
       - name: Report coverage
         run: npm run test:send
 
-  test-node-14:
-    name: Test Node.js v14
+  test-node-16:
+    name: Node.js v16
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
 
-      - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.3.0
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run test
+        run: npm run test
+
+  test-node-14:
+    name: Node.js v14
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          mongodb-version: '4.0'
+          node-version: '14'
 
       - name: Install dependencies
         run: npm ci
@@ -72,19 +62,14 @@ jobs:
         run: npm run test
 
   test-node-12:
-    name: Test Node.js v12
+    name: Node.js v12
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '12'
-
-      - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.3.0
-        with:
-          mongodb-version: '4.0'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           node-version: '18'
 
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.3.0
+        with:
+          mongodb-version: '4.0'
+
       - name: Install dependencies
         run: npm ci
 
@@ -36,6 +41,11 @@ jobs:
         with:
           node-version: '16'
 
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.3.0
+        with:
+          mongodb-version: '4.0'
+
       - name: Install dependencies
         run: npm ci
 
@@ -51,6 +61,11 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '14'
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.3.0
+        with:
+          mongodb-version: '4.0'
 
       - name: Install dependencies
         run: npm ci
@@ -70,6 +85,11 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '12'
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.3.0
+        with:
+          mongodb-version: '4.0'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Following saplingjs/sapling#519, se Node 18 LTS for the codecov report test run, and linting run. Add missing CodeQL workflows.

Retain Node 12 for now, even though it is EOL. If it ever causes major problems, it can be removed without worries.